### PR TITLE
Rework X and XWithContext to handle zero retries

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -21,6 +21,7 @@ package retry
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/rand"
 	"time"
 )
@@ -81,7 +82,7 @@ func XWithContext(ctx context.Context, x int, maxBackoff time.Duration, f func(c
 				// drain the timer chan
 				<-timer.C
 			}
-			return ctx.Err()
+			return fmt.Errorf("%w", ctx.Err())
 		case <-timer.C:
 			if latestErr = f(ctx); latestErr == nil {
 				// finished ok!
@@ -92,7 +93,7 @@ func XWithContext(ctx context.Context, x int, maxBackoff time.Duration, f func(c
 		timer.Reset(backoff(i+1, maxBackoff))
 	}
 	// ran out of retries
-	return latestErr
+	return fmt.Errorf("%w", latestErr)
 }
 
 // backoff with exponential delay. On try 0, duration will be zero.

--- a/retry.go
+++ b/retry.go
@@ -20,13 +20,13 @@ package retry
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"math/rand"
 	"time"
 )
 
 // X number of retries. Function f should return false if it
-// wants to stop trying, but never more than x calls of f
+// wants to stop trying, but never more than x+1 calls of f
 // are done. Calls to f have a sleep duration between them.
 //
 // Example 1:
@@ -39,10 +39,8 @@ import (
 // The use of "return err != nil" is an ideomatic way of
 // returning true, keep trying, when the error is not nil.
 func X(x int, maxBackoff time.Duration, f func() bool) {
-	for i := 0; i < x; i++ {
-		if i > 0 {
-			time.Sleep(backoff(i, maxBackoff))
-		}
+	for i := 0; i <= x; i++ {
+		time.Sleep(backoff(i, maxBackoff))
 		if !f() {
 			return
 		}
@@ -50,7 +48,7 @@ func X(x int, maxBackoff time.Duration, f func() bool) {
 }
 
 // XWithContext runs function f until f returns nil or the
-// number of retries exceeds x. Never more than x calls of f
+// number of retries exceeds x. Never more than x+1 calls of f
 // are done. Calls to f have a sleep duration between them.
 // XWithContext will return a wrapped error around f's errors
 // if all attempts fail.
@@ -59,27 +57,23 @@ func X(x int, maxBackoff time.Duration, f func() bool) {
 // to complete first.
 //
 // Example 1:
-//    retry.XWithContext(context.Background(), 3, 5*time.Second, func(ctx context.Context) error {
-//        err := DoSomething()
+//    retry.XWithContext(ctx, 3, 5*time.Second, func(ctx context.Context) error {
+//        err := DoSomething(ctx)
 //        return err
 //    })
 func XWithContext(ctx context.Context, x int, maxBackoff time.Duration, f func(ctx context.Context) error) error {
+	if x < 0 {
+		return errors.New("x cannot be less than 0")
+	}
+	if maxBackoff < 0 {
+		return errors.New("maxBackoff cannot be less than 0")
+	}
+
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
 	var latestErr error
-	var timer *time.Timer
-
-	defer func() {
-		if timer != nil {
-			timer.Stop()
-		}
-	}()
-
-	for i := 0; i < x; i++ {
-		if i == 0 {
-			timer = time.NewTimer(backoff(i, maxBackoff))
-		} else {
-			timer.Reset(backoff(i, maxBackoff))
-		}
-
+	for i := 0; i <= x; i++ {
 		select {
 		case <-ctx.Done():
 			// context cancelled
@@ -94,13 +88,11 @@ func XWithContext(ctx context.Context, x int, maxBackoff time.Duration, f func(c
 				return nil
 			}
 		}
+
+		timer.Reset(backoff(i+1, maxBackoff))
 	}
 	// ran out of retries
-	if latestErr != nil {
-		return fmt.Errorf("%w", latestErr)
-	}
-	// could happen when x < 1
-	return nil
+	return latestErr
 }
 
 // backoff with exponential delay. On try 0, duration will be zero.
@@ -111,20 +103,23 @@ func XWithContext(ctx context.Context, x int, maxBackoff time.Duration, f func(c
 // Backoff is useful if you don't want to use the retry.X but want
 // to calculate exponential backoff with jitter for your own use.
 func backoff(try int, max time.Duration) time.Duration {
-	if try < 1 {
-		return time.Duration(0)
-	}
-	if try > 3 {
+	switch {
+	case try < 1:
+		return 0
+	case try > 3, max == 0:
 		return max
 	}
+
 	// 2^3 == 8. If you change this value then
 	// you need to update the documentation.
-	min := max / time.Duration(8)
+	min := max / 8
 	jit := int64(min) * int64(try)
-	dur := time.Duration(min) << uint64(try)
+	dur := min << uint64(try)
 	dur += time.Duration(rand.Int63n(jit))
-	if dur < time.Duration(0) || dur > max {
-		return max
+
+	if dur < 0 || dur > max {
+		dur = max
 	}
+
 	return dur
 }

--- a/retry_test.go
+++ b/retry_test.go
@@ -11,69 +11,69 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFailingRetry(t *testing.T) {
+func TestXFailure(t *testing.T) {
+	t.Parallel()
 	n := 0
 	// Always returning true to try again, should
 	// eventually reach the max retries.
-	X(4, 1*time.Millisecond, func() bool {
+	X(4, time.Millisecond, func() bool {
 		n++
 		return true
 	})
-	assert.Equal(t, 4, n)
+	assert.Equal(t, 5, n)
 }
 
-func TestSuccessfulRetry(t *testing.T) {
+func TestXSuccess(t *testing.T) {
+	t.Parallel()
 	n := 0
 	// Returing false from the function should
 	// terminate the retries.
-	X(4, 1*time.Millisecond, func() bool {
+	X(4, time.Millisecond, func() bool {
 		n++
-		if n == 2 {
-			return false
-		}
-		return true
+		return n != 2
 	})
 	assert.Equal(t, 2, n)
 }
 
-func TestFailingRetryWithContext(t *testing.T) {
+func TestXWithContextFailure(t *testing.T) {
+	t.Parallel()
 	n := 0
 	ctx := context.Background()
 	// Always returning true to try again, should
 	// eventually reach the max retries.
 	var ErrOops = errors.New("oops")
-	err := XWithContext(ctx, 4, 1*time.Millisecond, func(ctx context.Context) error {
+	err := XWithContext(ctx, 4, time.Millisecond, func(context.Context) error {
 		n++
 		return fmt.Errorf("failure %v, %w", n, ErrOops)
 	})
-	assert.Equal(t, 4, n)
+	assert.Equal(t, 5, n)
 	// Make sure error is expected
-	assert.Equal(t, true, errors.Is(err, ErrOops))
-	assert.Equal(t, true, strings.Contains(err.Error(), fmt.Sprintf("failure %v", n)))
+	assert.True(t, errors.Is(err, ErrOops))
+	assert.True(t, strings.Contains(err.Error(), fmt.Sprintf("failure %v", n)))
 }
 
-func TestSuccessfulRetryWithContext(t *testing.T) {
+func TestXWithContextSuccess(t *testing.T) {
 	n := 0
 	ctx := context.Background()
 	// Returing false from the function should
 	// terminate the retries.
-	err := XWithContext(ctx, 4, 1*time.Millisecond, func(ctx context.Context) error {
+	err := XWithContext(ctx, 4, time.Millisecond, func(context.Context) error {
 		n++
 		if n == 2 {
 			return nil
 		}
 		return errors.New("oops")
 	})
+	assert.NoError(t, err)
 	assert.Equal(t, 2, n)
-	assert.Nil(t, err)
 }
 
-func TestCancelledRetryWithContext(t *testing.T) {
+func TestXWithContextCancelled(t *testing.T) {
 	n := 0
 	ctx, cancelFn := context.WithCancel(context.Background())
 	// Always returning true to try again, should
 	// eventually reach the max retries.
-	err := XWithContext(ctx, 4, 1*time.Millisecond, func(ctx context.Context) error {
+	err := XWithContext(ctx, 4, time.Millisecond, func(context.Context) error {
 		n++
 		if n == 2 {
 			cancelFn()
@@ -84,10 +84,63 @@ func TestCancelledRetryWithContext(t *testing.T) {
 	})
 	assert.Equal(t, 2, n)
 	// Make sure error is expected
-	assert.Equal(t, true, errors.Is(err, context.Canceled))
+	assert.True(t, errors.Is(err, context.Canceled))
+}
+
+func TestRetryWithContextNoRetries(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	var n int
+	someErr := errors.New("oops")
+
+	// When
+	err := XWithContext(context.Background(), 0, 0, func(context.Context) error {
+		n++
+		return someErr
+	})
+
+	// Then
+	assert.True(t, errors.Is(err, someErr))
+	assert.Equal(t, 1, n)
+}
+
+func TestRetryWithContextBadN(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	var n int
+
+	// When
+	err := XWithContext(context.Background(), -1, 0, func(context.Context) error {
+		n++
+		return nil
+	})
+
+	// Then
+	assert.Error(t, err)
+	assert.Zero(t, n)
+}
+
+func TestRetryWithContextBadMaxBackoff(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	var n int
+
+	// When
+	err := XWithContext(context.Background(), 0, -1, func(context.Context) error {
+		n++
+		return nil
+	})
+
+	// Then
+	assert.Error(t, err)
+	assert.Zero(t, n)
 }
 
 func TestBackoff(t *testing.T) {
+	t.Parallel()
 	const max = 8 * time.Second
 
 	// A value of i less than 1 should be set to 1.
@@ -98,7 +151,8 @@ func TestBackoff(t *testing.T) {
 	}
 }
 
-func TestTailBackoff(t *testing.T) {
+func TestBackoffTail(t *testing.T) {
+	t.Parallel()
 	const max = 8 * time.Second
 
 	// Test that beyond the third try,


### PR DESCRIPTION
# Changes

* Rework `X()` and `XWithContext()` to handle `n=0`.
* Miscellaneous cleanup.